### PR TITLE
Edge Type and Dev Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ cmake --build build -j4 --target install
 >[!WARNING]
 > For now, only the Python API and CLI work. Please do not turn off the option for Python bindings. It is
 > enabled by default.
-
-5. Try running the CLI tool, and it should print the help message:
+5. Create Python virtual environment and install dependencies as described in the [Pre-built Wheel](#1-pre-built-wheel) section.
+6. Install `readOH2csg` and run the CLI tool, and it should print the help message:
 ```bash
+# from the source directory
+python -m pip install .
 convert2degas2 --help
 ```
 
@@ -118,3 +120,5 @@ run the case following [OpenMC Documentation](https://docs.openmc.org).
 
 ## Documentation
 More details on strategies, logic, and math are included in the [`doc/`](doc/) directory.
+### Developer's Guide
+For myself and future development, use the [Developer's Guide](doc/DEVELOPERS_GUIDE.md) to understand the code structure, design decisions, and how to contribute to this project.

--- a/doc/DEVELOPERS_GUIDE.md
+++ b/doc/DEVELOPERS_GUIDE.md
@@ -1,0 +1,314 @@
+# Developer's Guide
+This project combines C++ and Python and the strategy is described in this [Blog Post](https://www.hasanfuad.com/post/binding-c-cpp-python/).
+It describes the packaging strategy and choices of tools.
+To get started with Python packaging, check out the [Python Packaging User Guide](https://packaging.python.org/en/latest/).
+
+## Formatting Style
+All codes in this project are formatted with formatting tools. All these formattings are enforced in the CI pipeline.
+
+>[!TIP] If formatting is passing locally but failing in CI, make sure you are using the same version of the formatting tools as specified in the CI pipeline.
+
+- C++ uses `clang-format` with the configuration specified in the [.clang-format](../.clang-format) file.
+- CMake files use `cmake-format` with the configuration specified in the [.cmake-format](../.cmake-format.yaml) file.
+- Python files uses [`ruff`](https://docs.astral.sh/ruff/formatter/) to format the code with the configuration specified in the [pyproject.toml](../pyproject.toml) file.
+
+### C++ and CMake Formatting
+The C++ codes use the [.clang-format](../.clang-format) file and to format the code, you can use `clang-format` tool
+with version 18 or later.
+
+Here's a script that can be used to format the C++ code in this project:
+```bash
+#!/bin/bash
+
+# Function to print colored output
+print_colored() {
+    local color=$1
+    local text=$2
+
+    case $color in
+        red)    echo -e "\033[0;31m$text\033[0m" ;;
+        green)  echo -e "\033[0;32m$text\033[0m" ;;
+        yellow) echo -e "\033[0;33m$text\033[0m" ;;
+        *)      echo -e "$text" ;;
+    esac
+}
+
+# Function to check if we're in a git repository
+check_git_repo() {
+    if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        print_colored "red" "✗ Error: Not in a git repository"
+        return 1
+    fi
+    return 0
+}
+
+# Function to check if command exists
+command_exists() {
+    command -v "$1" > /dev/null 2>&1
+}
+
+# Function to check C/C++ files formatting
+check_cpp_formatting() {
+    local all_good=true
+
+    # Check if clang-format exists
+    if ! command_exists clang-format; then
+        print_colored "yellow" "⚠ clang-format not found, skipping C/C++ file checks"
+        return 0
+    fi
+
+    # Get all tracked C/C++ files
+    local cpp_files
+    cpp_files=$(git ls-files 2>/dev/null | grep -E '\.(c|cpp|cc|cxx|h|hpp|hxx|hh)$' || true)
+
+    if [ -z "$cpp_files" ]; then
+        echo "No C/C++ files found in repository"
+        return 0
+    fi
+
+    print_colored "yellow" "Checking C/C++ files with clang-format..."
+
+    local bad_files=()
+    while IFS= read -r file; do
+        if [ -f "$file" ]; then
+            # Check if file needs formatting
+            if ! clang-format --dry-run --Werror "$file" > /dev/null 2>&1; then
+                print_colored "red" "✗ $file"
+                bad_files+=("$file")
+                all_good=false
+            fi
+        fi
+    done <<< "$cpp_files"
+
+    # Store bad files in global variable for fix suggestions
+    BAD_CPP_FILES=("${bad_files[@]}")
+
+    
+    if [ "$all_good" = true ]; then
+        print_colored "green" "✓ All C/C++ files are properly formatted!"
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to check CMake files formatting
+check_cmake_formatting() {
+    local all_good=true
+
+    # Check if cmake-format exists
+    if ! command_exists cmake-format; then
+        print_colored "yellow" "⚠ cmake-format not found, skipping CMake file checks"
+        return 0
+    fi
+
+    # Get all tracked CMake files
+    local cmake_files
+    cmake_files=$(git ls-files 2>/dev/null | grep -E 'CMakeLists\.txt$|\.cmake$' || true)
+
+    if [ -z "$cmake_files" ]; then
+        echo "No CMake files found in repository"
+        return 0
+    fi
+
+    echo ""
+    print_colored "yellow" "Checking CMake files with cmake-format..."
+
+    local bad_files=()
+    while IFS= read -r file; do
+        if [ -f "$file" ]; then
+            # Check if file needs formatting
+            if ! cmake-format --check "$file" > /dev/null 2>&1; then
+                print_colored "red" "✗ $file"
+                bad_files+=("$file")
+                all_good=false
+            fi
+        fi
+    done <<< "$cmake_files"
+
+    # Store bad files in global variable for fix suggestions
+    BAD_CMAKE_FILES=("${bad_files[@]}")
+
+    if [ "$all_good" = true ]; then
+        print_colored "green" "✓ All CMake files are properly formatted!"
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to show fix suggestions
+show_fix_suggestions() {
+    if [ ${#BAD_CPP_FILES[@]} -gt 0 ] || [ ${#BAD_CMAKE_FILES[@]} -gt 0 ]; then
+        echo ""
+        print_colored "yellow" "To fix formatting issues:"
+
+        if [ ${#BAD_CPP_FILES[@]} -gt 0 ]; then
+            echo ""
+            echo "C/C++ files:"
+            for file in "${BAD_CPP_FILES[@]}"; do
+                echo "  clang-format -i \"$file\""
+            done
+        fi
+
+        if [ ${#BAD_CMAKE_FILES[@]} -gt 0 ]; then
+            echo ""
+            echo "CMake files:"
+            for file in "${BAD_CMAKE_FILES[@]}"; do
+                echo "  cmake-format -i \"$file\""
+                            done
+        fi
+
+        echo ""
+        print_colored "yellow" "Or run all fixes at once:"
+        echo "  $0 --fix"
+    fi
+}
+
+# Function to apply fixes
+apply_fixes() {
+    local fixed_count=0
+
+    if command_exists clang-format; then
+        for file in "${BAD_CPP_FILES[@]}"; do
+            if [ -f "$file" ]; then
+                clang-format -i "$file"
+                print_colored "green" "✓ Fixed: $file"
+                ((fixed_count++))
+            fi
+        done
+    fi
+
+    if command_exists cmake-format; then
+        for file in "${BAD_CMAKE_FILES[@]}"; do
+            if [ -f "$file" ]; then
+                cmake-format -i "$file"
+                print_colored "green" "✓ Fixed: $file"
+                ((fixed_count++))
+            fi
+        done
+    fi
+
+    if [ $fixed_count -gt 0 ]; then
+        print_colored "green" "\n✓ Fixed $fixed_count file(s)"
+    fi
+}
+
+# Main function
+main() {
+    # Global arrays to store bad files
+    declare -a BAD_CPP_FILES
+    declare -a BAD_CMAKE_FILES
+
+    # Check for help or fix argument
+    if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+        echo "Usage: $0 [--fix | -h | --help]"
+        echo ""
+        echo "Check code formatting in a git repository."
+        echo ""
+        echo "Options:"
+        echo "  --fix     Apply fixes to improperly formatted files"
+        echo "  -h, --help Show this help message"
+        return 0
+    fi
+
+    # Check if we're in a git repository
+    if ! check_git_repo; then
+        return 1
+    fi
+
+    # Run checks
+    local cpp_ok=true
+    local cmake_ok=true
+
+    if ! check_cpp_formatting; then
+        cpp_ok=false
+    fi
+
+    if ! check_cmake_formatting; then
+        cmake_ok=false
+            fi
+
+    if ! check_cmake_formatting; then
+        cmake_ok=false
+    fi
+
+    # Show summary
+    echo ""
+    if [ "$cpp_ok" = true ] && [ "$cmake_ok" = true ]; then
+        print_colored "green" "All files are properly formatted!"
+        return 0
+    else
+        show_fix_suggestions
+
+        # Apply fixes if requested
+        if [[ "$1" == "--fix" ]]; then
+            echo ""
+            print_colored "yellow" "Applying fixes..."
+            apply_fixes
+        fi
+
+        return 1
+    fi
+}
+
+# Run main function with all arguments
+main "$@"
+```
+
+It will check both C++ and CMake files and print out the files that are not properly formatted.
+
+Run the following to check the formatting:
+```bash
+./check-format.sh
+```
+and if you want to apply the fixes, run:
+```bash
+./check-format.sh --fix
+```
+
+### Python Formatting
+The Python codes use `ruff` to format as well as lint the code.
+
+To check the formatting, run:
+```bash
+ruff format --check
+```
+and it will print the number of files that are not properly formatted. To apply the formatting, run:
+```bash
+ruff format
+```
+
+And lint the code with:
+```bash
+ruff check
+```
+
+## Installation
+Check the [README.md](../README.md) file for installation instructions. For development, install from source.
+To run the tests, install `pytest` and do:
+```bash
+python -m pip install -e .[test]
+```
+and run
+```bash
+pytest
+```
+
+## Packaging
+### Create Distribution Files
+After development and testing, to create the archive and wheel for distribution, install `build` using `pip` and run:
+
+```bash
+python -m build
+```
+which will create the distribution files in the `dist/` directory.
+
+### Upload to PyPI/TestPyPI
+To upload the distribution files to PyPI or TestPyPI, install `twine` using `pip` and run:
+```bash
+python -m twine upload --repository testpypi dist/*
+```
+
+It will require a `testpypi` `index-server` entry in your `~/.pypirc` file. See PyPI documentation
+for more details.

--- a/pythonAPI/omegah2csg/OmegaHMesh.py
+++ b/pythonAPI/omegah2csg/OmegaHMesh.py
@@ -6,6 +6,7 @@ from numpy.ctypeslib import ndpointer
 from ._lib import _dll
 from .config import kokkos_runtime
 import os
+from enum import IntEnum
 
 
 # Define C structures
@@ -15,6 +16,12 @@ class OmegaHLibraryPointer(Structure):
 
 class OmegaHMeshPointer(Structure):
     _fields_ = [("pointer", c_void_p)]
+
+
+class EdgeType(IntEnum):
+    Z_PLANE = 1
+    Z_CYLINDER = 2
+    Z_CONE = 3
 
 
 # Define function prototypes
@@ -101,6 +108,7 @@ _dll.capi_compute_edge_coefficients.argtypes = [
     OmegaHMeshPointer,
     c_int,
     ndpointer(c_double),
+    ndpointer(c_int),
     c_bool,
     c_double,
 ]
@@ -128,6 +136,7 @@ _dll.capi_get_all_geometry_info.argtypes = [
     c_int,
     c_int,
     ndpointer(c_double),
+    ndpointer(c_int),
     ndpointer(c_int),
     ndpointer(c_int),
     c_bool,
@@ -357,17 +366,18 @@ class OmegaHMesh:
 
         num_edges = self.num_entities(1)
         coefficients = np.zeros(num_edges * 6, dtype=np.float64)
+        edge_types = np.empty(num_edges, dtype=np.int32)
         size = coefficients.size
 
         try:
             _dll.capi_compute_edge_coefficients(
-                self.mesh, c_int(size), coefficients, print_debug, tol
+                self.mesh, c_int(size), coefficients, edge_types, print_debug, tol
             )
 
         except Exception as exception:
             raise RuntimeError(f"Error computing edge coefficients: {exception}")
 
-        return coefficients.reshape(num_edges, 6)
+        return coefficients.reshape(num_edges, 6), edge_types
 
     def get_num_of_boundary_edges(self) -> int:
         if not kokkos_runtime.is_running():
@@ -404,7 +414,7 @@ class OmegaHMesh:
         n_edges = self.num_entities(1)
 
         if edge_coefficients is None:
-            edge_coefficients = self.get_edge_coefficients()
+            edge_coefficients, edge_types_ = self.get_edge_coefficients()
 
         assert edge_coefficients.shape[0] == n_edges
         assert edge_coefficients.shape[1] == 6
@@ -438,6 +448,7 @@ class OmegaHMesh:
         n_edges = self.num_entities(1)
 
         edge_coefficients = np.zeros(n_edges * 6, dtype=np.float64)
+        edge_types = np.empty(n_edges, dtype=np.int32)
         boundary_edge_ids_num = self.get_num_of_boundary_edges()
         boundary_edge_ids = np.zeros(boundary_edge_ids_num, dtype=np.int32)
         face_connctivity = np.zeros(n_faces * 6, dtype=np.int32)
@@ -448,6 +459,7 @@ class OmegaHMesh:
                 n_edges,
                 n_faces,
                 edge_coefficients,
+                edge_types,
                 boundary_edge_ids,
                 face_connctivity,
                 print_debug,
@@ -458,6 +470,7 @@ class OmegaHMesh:
 
         return (
             edge_coefficients.reshape(n_edges, 6),
+            edge_types,
             boundary_edge_ids,
             face_connctivity.reshape(n_faces, 6),
         )

--- a/pythonAPI/omegah2csg/__init__.py
+++ b/pythonAPI/omegah2csg/__init__.py
@@ -5,7 +5,7 @@ from .OmegaHMesh import (
     read_face_connectivity_from_file,
 )
 from .convert2openmc import (
-    convert2openmc,
+    convert2openmcXML,
 )
 from .convert2degas2 import convert2degas2
 
@@ -18,7 +18,7 @@ __all__ = [
     "read_edge_coefficients_from_file",
     "read_face_connectivity_from_file",
     # openmc
-    "convert2openmc",
+    "convert2openmcXML",
     # degas2
     "convert2degas2",
 ]

--- a/pythonAPI/omegah2csg/convert2degas2/convert2degas2.py
+++ b/pythonAPI/omegah2csg/convert2degas2/convert2degas2.py
@@ -87,7 +87,7 @@ def convert2degas2(
         assert mesh.has_boundary_layer, (
             "Degas2 requires mesh to have a boundary layer. Use addBonudaryLayer tool from tomms."
         )
-        [edge_coefficients, boundary_edge_ids, face2edge_map] = (
+        [edge_coefficients, edge_types_, boundary_edge_ids, face2edge_map] = (
             mesh.get_all_geometry_info(tol=tol)
         )
         Ntri = face2edge_map.shape[0]  # ncells

--- a/pythonAPI/omegah2csg/convert2degas2/convert2degas2.py
+++ b/pythonAPI/omegah2csg/convert2degas2/convert2degas2.py
@@ -80,6 +80,22 @@ def write_dummy_bg_files_aux(nzone, nwall_input, stratum_start):
 def convert2degas2(
     mesh_filename, netcdf_filename="geometry.nc", create_aux_files=True, tol=1e-10
 ):
+    """Convert Omega_h mesh to Degas2 NetCDF geometry file and auxiliary files.
+
+    Parameters
+    ----------
+    mesh_filename : str
+        Path to the Omega_h mesh file (.osh) to be converted. This mesh must have a boundary layer. See [workflow documentation](https://gist.github.com/Fuad-HH/ea6d4913adcfb4d857ef2a77aebaaa2c)
+        for details on how to create such a mesh.
+    netcdf_filename : str, optional
+        Desired name for the output NetCDF file. Default is "geometry.nc".
+    create_aux_files : bool, optional
+        If True, creates auxiliary files (plasmafile.txt, sourcefile.txt, wallfile.txt) required for Degas2 simulations. Default is True.
+    tol : float, optional
+        Tolerance for numerical comparisons when determining edge orientations and other geometric properties. Default is 1e-10.
+
+    """
+
     assert netcdf_filename.endswith(".nc"), (
         "Degas2 mesh name should end with .nc but given {}".format(netcdf_filename)
     )

--- a/pythonAPI/omegah2csg/convert2openmc/__init__.py
+++ b/pythonAPI/omegah2csg/convert2openmc/__init__.py
@@ -9,8 +9,8 @@ from .convert2openmc import (
     create_z_plane,
     create_z_cylinder,
     create_openmc_surface,
-    create_openmc_geometry,
-    convert2openmc,
+    create_openmc_universe,
+    convert2openmcXML,
 )
 
 __all__ = [
@@ -24,6 +24,6 @@ __all__ = [
     "create_z_plane",
     "create_z_cylinder",
     "create_openmc_surface",
-    "create_openmc_geometry",
-    "convert2openmc",
+    "create_openmc_universe",
+    "convert2openmcXML",
 ]

--- a/pythonAPI/omegah2csg/convert2openmc/convert2openmc.py
+++ b/pythonAPI/omegah2csg/convert2openmc/convert2openmc.py
@@ -110,9 +110,29 @@ def create_openmc_surface(p1: Coord, p2: Coord, tol=1e-6):
     raise RuntimeError(f"Error creating surface: {p1} and {p2}")
 
 
-def create_openmc_geometry(
+def create_openmc_universe(
     mesh: OmegaHMesh, materials=None, print_debug=False, tol=1e-6
 ):
+    """Create OpenMC geometry (OpenMC.Universe) from OmegaHMesh by rorating along Z-axis
+
+    Parameters
+    ----------
+    mesh: OmegaHMesh
+        OmegaHMesh object with isOnWall and offset_face tags
+    materials: Any interable of size of number of cells, optional
+        Optional array of OpenMC materials to fill the cells. Size should match number of faces in the mesh.
+        If None, dummy materials will be used to avoid OpenMC errors.
+    print_debug: boo, optional
+        If True, prints edge coefficients and face connectivity for debugging.
+    tol: float, optional
+        Tolerance for determining edge types and connectivity. Should be a small positive number, e.g. 1e-6.
+
+    Returns
+    -------
+    OpenMC.Universe
+        OpenMC Universe object representing the geometry
+
+    """
     if not kokkos_runtime.is_running():
         raise RuntimeError("Kokkos not running...")
 
@@ -145,7 +165,6 @@ def create_openmc_geometry(
                 f"Z2 value {z2[i]} not recognized. Coefficients: {edge_coefficients[i, :]}"
             )
 
-    # this is incorrect as the above is appending
     for edge_id in boundary_edge_ids:
         edges[edge_id].boundary_type = "reflective"
 
@@ -188,11 +207,11 @@ def create_openmc_geometry(
     return universe
 
 
-def convert2openmc(filename, tol):
+def convert2openmcXML(filename, tol):
     assert filename.endswith(".osh")
     assert (tol < 1e-6) and (tol > 0.0)
 
     with OmegaHMesh(filename) as mesh:
-        universe = create_openmc_geometry(mesh=mesh, tol=tol)
+        universe = create_openmc_universe(mesh=mesh, tol=tol)
         geom = openmc.Geometry(universe)
         geom.export_to_xml()

--- a/pythonAPI/omegah2csg/convert2openmc/convert2openmc.py
+++ b/pythonAPI/omegah2csg/convert2openmc/convert2openmc.py
@@ -10,7 +10,7 @@ import numpy as np
 import openmc
 from typing import Tuple
 
-from ..OmegaHMesh import OmegaHMesh
+from ..OmegaHMesh import EdgeType, OmegaHMesh
 from ..config import kokkos_runtime
 
 
@@ -116,7 +116,7 @@ def create_openmc_geometry(
     if not kokkos_runtime.is_running():
         raise RuntimeError("Kokkos not running...")
 
-    [edge_coefficients, boundary_edge_ids, face_connctivity] = (
+    [edge_coefficients, edge_types, boundary_edge_ids, face_connctivity] = (
         mesh.get_all_geometry_info(print_debug, tol)
     )
     n_edges = mesh.num_entities(1)
@@ -130,11 +130,11 @@ def create_openmc_geometry(
     neg_c = edge_coefficients[:, 3]
 
     for i in range(len(intersections)):
-        if np.abs(m2[i]) < 1e-10:  # zplane
+        if edge_types[i] == EdgeType.Z_PLANE:
             edges[i] = openmc.ZPlane(z0=-neg_c[i])
-        elif np.isclose(z2[i], 0.0) and np.isclose(m2[i], 1.0):  # zcylinder
+        elif edge_types[i] == EdgeType.Z_CYLINDER:
             edges[i] = openmc.ZCylinder(r=np.sqrt(-neg_c[i]))
-        elif int(z2[i]) == -1:  # cone
+        elif edge_types[i] == EdgeType.Z_CONE:
             edges[i] = openmc.model.ZConeOneSided(
                 z0=intersections[i],
                 r2=1.0 / abs(m2[i]),

--- a/pythonAPI/omegah2csg/convert2openmc/convert2openmc_cli.py
+++ b/pythonAPI/omegah2csg/convert2openmc/convert2openmc_cli.py
@@ -1,6 +1,6 @@
 import argparse
 
-from .convert2openmc import convert2openmc
+from .convert2openmc import convert2openmcXML
 
 
 def main():
@@ -11,7 +11,7 @@ def main():
     parser.add_argument("--tol", type=float, help="tolerance", default=1e-10)
     args = parser.parse_args()
 
-    convert2openmc(filename=args.filename, tol=args.tol)
+    convert2openmcXML(filename=args.filename, tol=args.tol)
 
 
 # For setuptools entry point

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -17,12 +17,11 @@
 
 #include <cassert>
 
-extern "C" void capi_get_all_geometry_info(OmegaHMesh oh_mesh, int n_edges,
-                                           int n_faces,
-                                           double edge_coefficients[],
-                                           int boundary_edges[],
-                                           int face_connectivity[],
-                                           bool print_debug, const double tol) {
+extern "C" void
+capi_get_all_geometry_info(OmegaHMesh oh_mesh, int n_edges, int n_faces,
+                           double edge_coefficients[], int edge_types[],
+                           int boundary_edges[], int face_connectivity[],
+                           bool print_debug, const double tol) {
   auto mesh = reinterpret_cast<Omega_h::Mesh *>(oh_mesh.pointer);
   if (n_edges != mesh->nedges()) {
     throw std::runtime_error("Error: size of edge_coefficients array does not "
@@ -34,9 +33,11 @@ extern "C" void capi_get_all_geometry_info(OmegaHMesh oh_mesh, int n_edges,
   }
 
   // compute edge coefficients
+  auto edge_types_v = Kokkos::View<int *>("edge_types", mesh->nedges());
   auto edge_coefficients_view =
       Kokkos::View<double *[6]>("edge_coefficients", mesh->nedges());
-  compute_edge_coefficients(*mesh, edge_coefficients_view, print_debug, tol);
+  compute_edge_coefficients(*mesh, edge_coefficients_view, edge_types_v,
+                            print_debug, tol);
 
   // get boundary edge ids
   Omega_h::LOs boundary_edge_ids = get_boundary_edge_ids(*mesh);
@@ -58,6 +59,13 @@ extern "C" void capi_get_all_geometry_info(OmegaHMesh oh_mesh, int n_edges,
     for (int i = 0; i < 6; ++i) {
       edge_coefficients[edge * 6 + i] = host_edge_coefficients(edge, i);
     }
+  }
+
+  // copy edge types to output array
+  auto host_edge_types = Kokkos::create_mirror_view(edge_types_v);
+  Kokkos::deep_copy(host_edge_types, edge_types_v);
+  for (int edge_id = 0; edge_id < host_edge_types.extent(0); ++edge_id) {
+    edge_types[edge_id] = host_edge_types[edge_id];
   }
 
   // copy boundary edge ids to output array
@@ -214,6 +222,7 @@ extern "C" void kokkos_finalize() {
 
 extern "C" void capi_compute_edge_coefficients(OmegaHMesh oh_mesh, int size,
                                                double coefficients[],
+                                               int edge_types[],
                                                const bool print_debug,
                                                const double tol) {
   auto mesh = reinterpret_cast<Omega_h::Mesh *>(oh_mesh.pointer);
@@ -221,7 +230,9 @@ extern "C" void capi_compute_edge_coefficients(OmegaHMesh oh_mesh, int size,
   auto edge_coefficients_view =
       Kokkos::View<double *[6]>("edge_coefficients_view", n_edges);
 
-  compute_edge_coefficients(*mesh, edge_coefficients_view, print_debug, tol);
+  auto edge_types_v = Kokkos::View<int *>("edge_types", n_edges);
+  compute_edge_coefficients(*mesh, edge_coefficients_view, edge_types_v,
+                            print_debug, tol);
   auto host_edge_coefficients_view =
       Kokkos::create_mirror_view(edge_coefficients_view);
   Kokkos::deep_copy(host_edge_coefficients_view, edge_coefficients_view);
@@ -236,6 +247,13 @@ extern "C" void capi_compute_edge_coefficients(OmegaHMesh oh_mesh, int size,
     for (int i = 0; i < 6; ++i) {
       coefficients[edge * 6 + i] = host_edge_coefficients_view(edge, i);
     }
+  }
+
+  // copy edge types to output array
+  const auto host_edge_types = Kokkos::create_mirror_view(edge_types_v);
+  Kokkos::deep_copy(host_edge_types, edge_types_v);
+  for (int edge_id = 0; edge_id < host_edge_types.extent(0); ++edge_id) {
+    edge_types[edge_id] = host_edge_types[edge_id];
   }
 }
 

--- a/src/capi.h
+++ b/src/capi.h
@@ -39,8 +39,8 @@ void kokkos_initialize();
 void kokkos_finalize();
 
 void capi_compute_edge_coefficients(OmegaHMesh oh_mesh, int size,
-                                    double coefficients[], bool print_debug,
-                                    double tol = 1e-6);
+                                    double coefficients[], int edge_types[],
+                                    bool print_debug, double tol = 1e-6);
 
 int capi_get_number_of_boundary_edges(OmegaHMesh oh_mesh);
 void capi_get_boundary_edge_ids(OmegaHMesh oh_mesh, int size, int edge_ids[]);
@@ -51,7 +51,7 @@ void capi_get_face_connectivity(OmegaHMesh oh_mesh, int edge_size,
                                 double tol = 1e-6);
 
 void capi_get_all_geometry_info(OmegaHMesh oh_mesh, int n_edges, int n_faces,
-                                double edge_coefficients[],
+                                double edge_coefficients[], int edge_types[],
                                 int boundary_edges[], int face_connectivity[],
                                 bool print_debug, double tol = 1e-6);
 

--- a/src/compute_surface.cpp
+++ b/src/compute_surface.cpp
@@ -202,8 +202,10 @@ calculate_face_connectivity(Omega_h::Mesh mesh,
 
 void compute_edge_coefficients(Omega_h::Mesh &mesh,
                                Kokkos::View<double *[6]> edge_coefficients_v,
+                               Kokkos::View<int *> edge_type_v,
                                const bool print_flag, const double tol) {
   assert(edge_coefficients_v.extent(0) == mesh.nedges());
+  assert(edge_type_v.extent(0) == mesh.nedges());
 
   const auto edgeVertices = mesh.ask_down(Omega_h::EDGE, Omega_h::VERT).ab2b;
 
@@ -229,12 +231,15 @@ void compute_edge_coefficients(Omega_h::Mesh &mesh,
     if (std::abs(v1coords[0] - v2coords[0]) < tol) {
       // cylinder surface: x^2 + y^2 - r^2 = 0
       edge_coefficients = {1.0, 0.0, 0.0, -v1coords[0] * v1coords[0], 0, 1.0};
+      edge_type_v(i) = 2;
     } else if (std::abs(v1coords[1] - v2coords[1]) < tol) {
       // z plane: z-z0 = 0
       edge_coefficients = {0.0, 0.0, 1.0, -v1coords[1], 0, 0};
+      edge_type_v(i) = 1;
     } else {
       // compute the coefficients of the line passing through vert1 and vert2
       edge_coefficients = compute_coefficients(v1coords, v2coords);
+      edge_type_v(i) = 3;
     }
 
     // store the coefficients view

--- a/src/compute_surface.h
+++ b/src/compute_surface.h
@@ -32,10 +32,12 @@ calculate_face_connectivity(Omega_h::Mesh mesh,
  * @param mesh Input mesh
  * @param print_flag Print flag for debugging
  * @param edge_coefficients_v Output edge coefficients of size (num_edges, 6)
+ * @param edge_type_v Edge type (z-plane -> 1, z-cylinder -> 2, z-cone -> 3)
  * @param tol Tolerance for numerical comparisons
  */
 void compute_edge_coefficients(Omega_h::Mesh &mesh,
                                Kokkos::View<double *[6]> edge_coefficients_v,
+                               Kokkos::View<int *> edge_type_v,
                                bool print_flag = false, double tol = 1e-10);
 
 [[nodiscard]] Omega_h::LOs get_boundary_edge_ids(Omega_h::Mesh &mesh);

--- a/tests/test_openmc_geometry_creation.py
+++ b/tests/test_openmc_geometry_creation.py
@@ -146,17 +146,14 @@ def test_edge_and_face_coefficients():
     intersections = edge_coefficients[:, 3]
     m2 = edge_coefficients[:, 1]
     z2 = edge_coefficients[:, 2]
-    neg_c = edge_coefficients[:, 4]
+    neg_c = edge_coefficients[:, 3]
 
     for i in range(len(intersections)):
         if edge_types[i] == EdgeType.Z_PLANE:
-            # print("Zplane - id ", int(data[i][0]))
             edges.append(openmc.ZPlane(z0=-neg_c[i]))
         elif edge_types[i] == EdgeType.Z_CYLINDER:
-            # print("Quad - id ", int(data[i][0]))
             edges.append(openmc.ZCylinder(r=np.sqrt(-neg_c[i])))
         elif edge_types[i] == EdgeType.Z_CONE:
-            # print("Cone - id ", int(data[i][0]), " flag ", top_bottom_flag[i])
             edges.append(
                 openmc.model.ZConeOneSided(
                     z0=intersections[i],

--- a/tests/test_openmc_geometry_creation.py
+++ b/tests/test_openmc_geometry_creation.py
@@ -3,7 +3,7 @@ import openmc
 
 import pandas as pd
 from omegah2csg import OmegaHMesh
-from omegah2csg.convert2openmc import create_openmc_geometry
+from omegah2csg.convert2openmc import create_openmc_universe
 from omegah2csg import read_edge_coefficients_from_file
 from omegah2csg import read_face_connectivity_from_file
 from omegah2csg.OmegaHMesh import EdgeType
@@ -118,7 +118,7 @@ def test_all_gemetry_info_16_element_mesh():
 
 def test_create_openmc_universe():
     with OmegaHMesh(parent_directory / "assets/6elem.osh") as mesh:
-        universe = create_openmc_geometry(mesh)
+        universe = create_openmc_universe(mesh)
         geom = openmc.Geometry(universe)
         geom.export_to_xml()
 

--- a/tests/test_openmc_geometry_creation.py
+++ b/tests/test_openmc_geometry_creation.py
@@ -6,6 +6,7 @@ from omegah2csg import OmegaHMesh
 from omegah2csg.convert2openmc import create_openmc_geometry
 from omegah2csg import read_edge_coefficients_from_file
 from omegah2csg import read_face_connectivity_from_file
+from omegah2csg.OmegaHMesh import EdgeType
 
 from pathlib import Path
 
@@ -29,9 +30,12 @@ def test_read_from_file():
     )
 
     with OmegaHMesh(parent_directory / "assets/6elem.osh") as mesh:
-        [edge_coefficients_api, boundary_edge_ids_api, face_connectivity_api] = (
-            mesh.get_all_geometry_info()
-        )
+        [
+            edge_coefficients_api,
+            edge_types_,
+            boundary_edge_ids_api,
+            face_connectivity_api,
+        ] = mesh.get_all_geometry_info()
 
     # compare boundary edges
     assert boundary_edge_ids_api.ndim == 1
@@ -61,9 +65,9 @@ def test_read_from_file():
             assert face_connectivity_api[i, j] == face_connectivity_file[i, j]
 
 
-def test_all_gemetry_info():
+def test_all_gemetry_info_6element_mesh():
     with OmegaHMesh(parent_directory / "assets/6elem.osh") as mesh:
-        [edge_coefficients, boundary_edge_ids, face_connctivity] = (
+        [edge_coefficients, edge_types, boundary_edge_ids, face_connctivity] = (
             mesh.get_all_geometry_info()
         )
         print(pd.DataFrame(edge_coefficients))
@@ -78,6 +82,39 @@ def test_all_gemetry_info():
     assert face_connctivity.shape[0] == 6
     assert face_connctivity.shape[1] == 6
 
+    n_cones = 10
+    n_cylinders = 3
+    n_planes = 0
+    assert np.sum(edge_types == EdgeType.Z_CONE) == n_cones
+    assert np.sum(edge_types == EdgeType.Z_CYLINDER) == n_cylinders
+    assert np.sum(edge_types == EdgeType.Z_PLANE) == n_planes
+
+
+def test_all_gemetry_info_16_element_mesh():
+    with OmegaHMesh(parent_directory / "assets/16elem.osh") as mesh:
+        [edge_coefficients, edge_types, boundary_edge_ids, face_connctivity] = (
+            mesh.get_all_geometry_info(tol=1e-4)
+        )
+        print(pd.DataFrame(edge_coefficients))
+        print(pd.DataFrame(boundary_edge_ids))
+        print(pd.DataFrame(face_connctivity))
+
+    assert edge_coefficients.shape[0] == 30
+    assert edge_coefficients.shape[1] == 6
+
+    assert boundary_edge_ids.shape[0] == 12
+
+    assert face_connctivity.shape[0] == 16
+    assert face_connctivity.shape[1] == 6
+
+    n_cones = 24
+    n_cylinders = 4
+    n_planes = 2
+    assert n_cones + n_cylinders + n_planes == edge_coefficients.shape[0]
+    assert np.sum(edge_types == EdgeType.Z_CONE) == n_cones
+    assert np.sum(edge_types == EdgeType.Z_CYLINDER) == n_cylinders
+    assert np.sum(edge_types == EdgeType.Z_PLANE) == n_planes
+
 
 def test_create_openmc_universe():
     with OmegaHMesh(parent_directory / "assets/6elem.osh") as mesh:
@@ -89,7 +126,7 @@ def test_create_openmc_universe():
 def test_edge_and_face_coefficients():
     tol = 1e-10
     with OmegaHMesh(parent_directory / "assets/6elem.osh") as mesh:
-        edge_coefficients = mesh.get_edge_coefficients(tol=tol)
+        edge_coefficients, edge_types = mesh.get_edge_coefficients(tol=tol)
         boundary_edge_ids = mesh.get_boundary_edge_ids()
         n_faces = mesh.num_entities(2)
         n_edges = mesh.num_entities(1)
@@ -112,17 +149,13 @@ def test_edge_and_face_coefficients():
     neg_c = edge_coefficients[:, 4]
 
     for i in range(len(intersections)):
-        if abs(m2[i]) < 1e-10:  # zplane
+        if edge_types[i] == EdgeType.Z_PLANE:
             # print("Zplane - id ", int(data[i][0]))
             edges.append(openmc.ZPlane(z0=-neg_c[i]))
-        elif abs(z2[i] + 1) > 1e-10:  # not a cone
+        elif edge_types[i] == EdgeType.Z_CYLINDER:
             # print("Quad - id ", int(data[i][0]))
-            edges.append(
-                openmc.Quadric(
-                    a=m2[i], b=m2[i], c=z2[i], j=intersections[i], k=neg_c[i]
-                )
-            )
-        else:  # cone
+            edges.append(openmc.ZCylinder(r=np.sqrt(-neg_c[i])))
+        elif edge_types[i] == EdgeType.Z_CONE:
             # print("Cone - id ", int(data[i][0]), " flag ", top_bottom_flag[i])
             edges.append(
                 openmc.model.ZConeOneSided(
@@ -130,6 +163,10 @@ def test_edge_and_face_coefficients():
                     r2=1.0 / abs(m2[i]),
                     up=True if top_bottom_flag[i] == 1 else False,
                 )
+            )
+        else:
+            raise RuntimeError(
+                f"Z2 value {z2[i]} not recognized. Coefficients: {edge_coefficients[i, :]}"
             )
 
     assert edge_coefficients.shape[0] == 13


### PR DESCRIPTION
It makes edge type handling consistent. Fixes #11 

Local tests are working and have been checked with the ITER case.

- Introduced EdgeType enum for edge classification (Z_PLANE, Z_CYLINDER, Z_CONE).
- Modified geometry functions to return edge types alongside coefficients.
- Updated C API to support edge type retrieval.
- Adjusted compute_edge_coefficients to populate edge types.
- Enhanced tests to validate edge type counts and classifications.