### PR TITLE
Enhance convert2degas2 function and CLI with new options

### DIFF
--- a/pythonAPI/omegah2csg/convert2degas2/convert2degas2.py
+++ b/pythonAPI/omegah2csg/convert2degas2/convert2degas2.py
@@ -78,7 +78,12 @@ def write_dummy_bg_files_aux(nzone, nwall_input, stratum_start):
 
 
 def convert2degas2(
-    mesh_filename, netcdf_filename="geometry.nc", create_aux_files=True, tol=1e-10
+    mesh_filename,
+    netcdf_filename="geometry.nc",
+    create_aux_files=True,
+    tol=1e-10,
+    target_temperature_K=300.0,
+    target_recyc_coef=0.50,
 ):
     """Convert Omega_h mesh to Degas2 NetCDF geometry file and auxiliary files.
 
@@ -93,6 +98,10 @@ def convert2degas2(
         If True, creates auxiliary files (plasmafile.txt, sourcefile.txt, wallfile.txt) required for Degas2 simulations. Default is True.
     tol : float, optional
         Tolerance for numerical comparisons when determining edge orientations and other geometric properties. Default is 1e-10.
+    target_temperature_K : float, optional
+        Target temperature in Kelvin. Default is 300.0.
+    target_recyc_coef : float, optional
+        Target recycling coefficient. Default is 0.50.
 
     """
 
@@ -773,9 +782,10 @@ def convert2degas2(
     sc_diag_max_bins_var[:] = sc_diag_max_bins
     sc_vacuum_num_var[:] = sc_vacuum_num
 
-    # target_temperature = np.zeros(sc_target_num+1) # ask
-    Twall = 300 * 1.380649e-23
-    target_temperature = Twall * np.ones(sc_target_num + 1)
+    # Temperature in jules
+    boltzmann_constant = 1.380649e-23  # J/K
+    target_temperature_j = target_temperature_K * boltzmann_constant
+    target_temperature = target_temperature_j * np.ones(sc_target_num + 1)
     target_temperature[0] = DBL_UNUSED
     target_temperature_var[:] = target_temperature
 
@@ -802,8 +812,7 @@ def convert2degas2(
     wall_material_var[:] = wall_material
     wall_temperature_var[:] = wall_temperature
 
-    recyc_coef = 0.99
-    target_recyc_coef = recyc_coef * np.ones(sc_target_num + 1)
+    target_recyc_coef = target_recyc_coef * np.ones(sc_target_num + 1)
     target_recyc_coef[0] = DBL_UNUSED
     target_recyc_coef_var[:] = target_recyc_coef
 

--- a/pythonAPI/omegah2csg/convert2degas2/convert2degas2_cli.py
+++ b/pythonAPI/omegah2csg/convert2degas2/convert2degas2_cli.py
@@ -6,28 +6,59 @@ from .convert2degas2 import convert2degas2
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Convert Omega_h mesh to DEGAS2 geometry (netcdf file)"
+        description="Convert Omega_h mesh to DEGAS2 geometry (netcdf file)",
+        epilog="Example usage: %(prog)s  mesh.osh --tol 1e-8 --auxfiles --target-temperature 300 --target-recyc-coef 0.5",
     )
     parser.add_argument(
         "--version",
+        "-v",
         action="version",
         version=f"%(prog)s {__version__}",
     )
-    parser.add_argument("filename", help="Omega_h mesh file (.osh)")
-    parser.add_argument("--tol", type=float, help="tolerance", default=1e-10)
+    parser.add_argument(
+        "filename",
+        help="Omega_h mesh file (.osh). The mesh must have a boundary rectangle defined with tag 'offset_face' and wall nodes as 'isOnWall'. Check the documentation for details.",
+    )
+    parser.add_argument(
+        "--tol",
+        type=float,
+        default=1e-10,
+        help="Tolerance for geometric comparisons (default: 1e-10). Try smaller values if you encounter issues with finer meshes.",
+    )
     parser.add_argument(
         "--auxfiles",
-        type=bool,
-        help="create dummy auxiliary files for degas2 case",
-        default=False,
+        "-a",
+        action="store_true",
+        help="Create auxiliary files (plasmafile.txt, sourcefile.txt, wallfile.txt) required for Degas2 simulations",
+    )
+    parser.add_argument(
+        "--target-temperature",
+        type=float,
+        default=300.0,
+        help="Target temperature in Kelvin (default: 300 K)",
+    )
+    parser.add_argument(
+        "--output-filename",
+        "-o",
+        type=str,
+        default="geometry.nc",
+        help="Output netCDF filename (default: geometry.nc)",
+    )
+    parser.add_argument(
+        "--target-recyc-coef",
+        type=float,
+        default=0.50,
+        help="Target recycling coefficient (default: 0.50)",
     )
     args = parser.parse_args()
 
     convert2degas2(
         mesh_filename=args.filename,
         tol=args.tol,
-        netcdf_filename="geometry.nc",
+        netcdf_filename=args.output_filename,
         create_aux_files=args.auxfiles,
+        target_temperature_K=args.target_temperature,
+        target_recyc_coef=args.target_recyc_coef,
     )
 
 


### PR DESCRIPTION
Changes:

* Added `target_temperature_K` and `target_recyc_coef` as optional parameters to the `convert2degas2` function, allowing users to set the target temperature (in Kelvin) and recycling coefficient for simulations. These values are now used in the generated output instead of hardcoded defaults. [[1]](diffhunk://#diff-f2e816af4813c923b551af838fc7a358adaf9eacdf4fc9ae1cae622ae6cd7bbdL81-R86) [[2]](diffhunk://#diff-f2e816af4813c923b551af838fc7a358adaf9eacdf4fc9ae1cae622ae6cd7bbdR101-R104) [[3]](diffhunk://#diff-f2e816af4813c923b551af838fc7a358adaf9eacdf4fc9ae1cae622ae6cd7bbdL776-R788) [[4]](diffhunk://#diff-f2e816af4813c923b551af838fc7a358adaf9eacdf4fc9ae1cae622ae6cd7bbdL805-R815)
* Updated the CLI (`convert2degas2_cli.py`) to accept `--target-temperature` and `--target-recyc-coef` arguments, as well as improved descriptions for all arguments, an example usage in the help text, and a new `--output-filename` option for specifying the output file name.